### PR TITLE
Valgrind

### DIFF
--- a/cli/base64.c
+++ b/cli/base64.c
@@ -33,7 +33,6 @@ unsigned char * base64_encode(const unsigned char *src, size_t len,
 	unsigned char *out, *pos;
 	const unsigned char *end, *in;
 	size_t olen;
-	int line_len;
 
 	olen = len * 4 / 3 + 4; /* 3-byte blocks to 4-byte */
 	olen += 2; /* nul termination and line feed */
@@ -46,7 +45,6 @@ unsigned char * base64_encode(const unsigned char *src, size_t len,
 	end = src + len;
 	in = src;
 	pos = out;
-	line_len = 0;
 	while (end - in >= 3) {
 		*pos++ = base64_table[in[0] >> 2];
 		*pos++ = base64_table[((in[0] & 0x03) << 4) | (in[1] >> 4)];

--- a/tests/unicode.c
+++ b/tests/unicode.c
@@ -127,15 +127,15 @@ void test_unicode__utf8to16_zero_length_string(void)
 
 void test_unicode__utf8to16_simple(void)
 {
-	char a[] =         { 'a', 0 };
-	char ab[] =        { 'a', 0, 'b', 0 };
-	char abc[] =       { 'a', 0, 'b', 0, 'c', 0 };
-	char abcd[] =      { 'a', 0, 'b', 0, 'c', 0, 'd', 0 };
-	char abcde[] =     { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0 };
-	char abcdef[] =    { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0 };
-	char abcdefg[] =   { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0, 'g', 0 };
-	char abcdefgh[] =  { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0, 'g', 0, 'h', 0 };
-	char abcdefghi[] = { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0, 'g', 0, 'h', 0, 'i', 0 };
+	char a[] =         { 'a', 0, 0, 0 };
+	char ab[] =        { 'a', 0, 'b', 0, 0, 0 };
+	char abc[] =       { 'a', 0, 'b', 0, 'c', 0, 0, 0 };
+	char abcd[] =      { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 0, 0 };
+	char abcde[] =     { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 0, 0 };
+	char abcdef[] =    { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0, 0, 0 };
+	char abcdefg[] =   { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0, 'g', 0, 0, 0 };
+	char abcdefgh[] =  { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0, 'g', 0, 'h', 0, 0, 0 };
+	char abcdefghi[] = { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 'f', 0, 'g', 0, 'h', 0, 'i', 0, 0, 0 };
 
 	assert_utf8_to_16(ctx, a, "a", 1);
 	assert_utf8_to_16(ctx, ab, "ab", 2);
@@ -150,7 +150,7 @@ void test_unicode__utf8to16_simple(void)
 
 void test_unicode__utf8to16_honors_length(void)
 {
-	char abcde[] = { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0 };
+	char abcde[] = { 'a', 0, 'b', 0, 'c', 0, 'd', 0, 'e', 0, 0, 0};
 
 	assert_utf8_to_16(ctx, abcde, "abcdefghijklmnop", 5);
 }


### PR DESCRIPTION
Valgrind detected that our tests did not NUL-terminate the utf16 expected data correctly.  The compiler detected a now-unused variable in the base64 conversion functionality.