### PR TITLE
Fix a few warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ ELSE()
 	MESSAGE(FATAL_ERROR "invalid cryptographic support requested: ${CRYPT}")
 ENDIF()
 
+SET(CMAKE_C_FLAGS "-std=c99 -D_DEFAULT_SOURCE")
+
 ENABLE_WARNINGS(all)
 ENABLE_WARNINGS(extra)
 ENABLE_WARNINGS(documentation)

--- a/cli/ntlm_cli.c
+++ b/cli/ntlm_cli.c
@@ -18,7 +18,7 @@ enum ntlm_cli_type {
 	NTLM_CLI_RESPONSE
 };
 
-static int read_challenge(unsigned char **out, size_t *out_len, int raw)
+static void read_challenge(unsigned char **out, size_t *out_len, int raw)
 {
 	unsigned char *msg, *base64;
 	size_t msg_len = 0, base64_len, remain = 10240;
@@ -31,7 +31,7 @@ static int read_challenge(unsigned char **out, size_t *out_len, int raw)
 		ret = read(STDIN_FILENO, msg + msg_len, remain);
 
 		if (ret < 0)
-			return -1;
+			die("could not read challenge");
 		else if (ret == 0)
 			break;
 
@@ -53,8 +53,6 @@ static int read_challenge(unsigned char **out, size_t *out_len, int raw)
 		*out = base64;
 		*out_len = base64_len;
 	}
-
-	return 0;
 }
 
 static void show_message(const unsigned char *msg, size_t msg_len, int raw)
@@ -162,8 +160,7 @@ int main(int argc, char **argv)
 		if (ntlm_client_negotiate(&message, &message_len, ntlm))
 			die(ntlm_client_errmsg(ntlm));
 	} else {
-		if (read_challenge(&challenge, &challenge_len, raw))
-			die(strerror(errno));
+		read_challenge(&challenge, &challenge_len, raw);
 
 		if (ntlm_client_set_challenge(ntlm, challenge, challenge_len) ||
 			ntlm_client_response(&message, &message_len, ntlm))

--- a/src/crypt_openssl.c
+++ b/src/crypt_openssl.c
@@ -120,9 +120,6 @@ bool ntlm_hmac_md5_final(
 	if (!HMAC_Final(ctx, out, &len))
 		return false;
 
-	if (len > UINT_MAX)
-		return false;
-
 	*out_len = len;
 	return true;
 }


### PR DESCRIPTION
Remove a few warnings - fix a memory leak in the CLI, remove an unnecessary sanity check, add `-std=c99` to the build flags.