### PR TITLE
initialize hostname_len and domain_len

### DIFF
--- a/src/ntlm.c
+++ b/src/ntlm.c
@@ -587,7 +587,9 @@ int ntlm_client_negotiate(
 	size_t *out_len,
 	ntlm_client *ntlm)
 {
-	size_t hostname_len, hostname_offset, domain_len, domain_offset;
+	size_t hostname_len, domain_len;
+	size_t domain_offset = 0;
+	size_t hostname_offset = 0;
 	uint32_t flags = 0;
 
 	assert(out && out_len && ntlm);


### PR DESCRIPTION
This isn't necessary for correctness,
but it prevents warnings for some compilers
using -Wmaybe-uninitialized.

Reported in https://github.com/libgit2/libgit2/issues/5353