### PR TITLE
Provide our own htonll

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -21,33 +21,6 @@
 # include <stdbool.h>
 #endif
 
-#ifdef __linux__
-/* See man page endian(3) */
-# include <endian.h>
-# define htonll htobe64
-#elif defined(__NetBSD__) || defined(__OpenBSD__)
-/* See man page htobe64(3) */
-# include <endian.h>
-# define htonll htobe64
-#elif defined(__FreeBSD__)
-/* See man page bwaps64(9) */
-# include <sys/endian.h>
-# define htonll htobe64
-#elif defined(sun) || defined(__sun)
-/* See man page byteorder(3SOCKET) */
-# include <sys/types.h>
-# include <netinet/in.h>
-# include <inttypes.h>
-
-# if !defined(htonll)
-#  if defined(_BIG_ENDIAN)
-#   define htonll(x) (x)
-#  else
-#   define htonll(x) ((((uint64_t)htonl(x)) << 32) + htonl((uint64_t)(x) >> 32))
-#  endif
-# endif
-#endif
-
 #ifndef MIN
 # define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif

--- a/src/crypt_openssl.c
+++ b/src/crypt_openssl.c
@@ -71,7 +71,7 @@ static inline void HMAC_CTX_free(HMAC_CTX *ctx)
 static inline int HMAC_CTX_reset(HMAC_CTX *ctx)
 {
 	HMAC_CTX_cleanup(ctx);
-	memzero(ctx, sizeof(HMAC_CTX));
+	ntlm_memzero(ctx, sizeof(HMAC_CTX));
 	return 1;
 }
 

--- a/src/ntlm.c
+++ b/src/ntlm.c
@@ -134,10 +134,10 @@ int ntlm_client_set_hostname(
 static void free_credentials(ntlm_client *ntlm)
 {
 	if (ntlm->password)
-		memzero(ntlm->password, strlen(ntlm->password));
+		ntlm_memzero(ntlm->password, strlen(ntlm->password));
 
 	if (ntlm->password_utf16)
-		memzero(ntlm->password_utf16, ntlm->password_utf16_len);
+		ntlm_memzero(ntlm->password_utf16, ntlm->password_utf16_len);
 
 	free(ntlm->username);
 	free(ntlm->username_upper);

--- a/src/ntlm.c
+++ b/src/ntlm.c
@@ -1126,7 +1126,7 @@ static bool generate_lm2_response(ntlm_client *ntlm,
 	size_t lm2_len = 16;
 	uint64_t local_nonce;
 
-	local_nonce = htonll(ntlm->nonce);
+	local_nonce = ntlm_htonll(ntlm->nonce);
 
 	if (!ntlm_hmac_ctx_reset(ntlm->hmac_ctx) ||
 		!ntlm_hmac_md5_init(ntlm->hmac_ctx,
@@ -1198,8 +1198,8 @@ static bool generate_ntlm2_response(ntlm_client *ntlm)
 
 	/* the blob's integer values are in network byte order */
 	signature = htonl(0x01010000);
-	timestamp = htonll(ntlm->timestamp);
-	nonce = htonll(ntlm->nonce);
+	timestamp = ntlm_htonll(ntlm->timestamp);
+	nonce = ntlm_htonll(ntlm->nonce);
 
 	/* construct the blob */
 	memcpy(&blob[0], &signature, 4);

--- a/src/util.c
+++ b/src/util.c
@@ -12,7 +12,7 @@
 #include "compat.h"
 #include "util.h"
 
-void memzero(void *data, size_t size)
+void ntlm_memzero(void *data, size_t size)
 {
 	volatile uint8_t *scan = (volatile uint8_t *)data;
 

--- a/src/util.c
+++ b/src/util.c
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <arpa/inet.h>
 
 #include "compat.h"
 #include "util.h"
@@ -18,4 +19,17 @@ void ntlm_memzero(void *data, size_t size)
 
 	while (size--)
 		*scan++ = 0x0;
+}
+
+uint64_t ntlm_htonll(uint64_t value)
+{
+	static union {
+		uint32_t i;
+		char c[8];
+	} test = { 0x01020304 };
+
+	if (test.c[0] == 0x01)
+		return value;
+	else
+		return ((uint64_t)htonl(value) << 32) | htonl((uint64_t)value >> 32);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -10,5 +10,6 @@
 #define PRIVATE_UTIL_H__
 
 extern void ntlm_memzero(void *data, size_t size);
+extern uint64_t ntlm_htonll(uint64_t value);
 
 #endif /* PRIVATE_UTIL_H__ */

--- a/src/util.h
+++ b/src/util.h
@@ -9,6 +9,6 @@
 #ifndef PRIVATE_UTIL_H__
 #define PRIVATE_UTIL_H__
 
-extern void memzero(void *data, size_t size);
+extern void ntlm_memzero(void *data, size_t size);
 
 #endif /* PRIVATE_UTIL_H__ */

--- a/tests/challenge.c
+++ b/tests/challenge.c
@@ -88,7 +88,7 @@ void test_challenge__sample(void)
 	cl_ntlm_pass(ntlm, ntlm_client_set_challenge(ntlm,
 			challenge_msg, sizeof(challenge_msg)));
 
-	cl_assert_equal_i(htonll(0x0123456789abcdef),
+	cl_assert_equal_i(ntlm_htonll(0x0123456789abcdef),
 		ntlm_client_challenge_nonce(ntlm));
 
 	cl_assert_equal_s("DOMAIN", ntlm_client_target(ntlm));

--- a/tests/ntlm_tests.h
+++ b/tests/ntlm_tests.h
@@ -3,6 +3,7 @@
 
 #include "clar.h"
 #include "ntlm.h"
+#include "util.h"
 
 #define cl_ntlm_pass(ntlm, expr) cl_ntlm_expect((ntlm), (expr), 0, __FILE__, __LINE__)
 


### PR DESCRIPTION
Instead of brittle tests to try to delegate to a system's version of a 64-bit byte order conversion function, include our own.
