### PR TITLE
api: soft-fail input errors

### DIFF
--- a/include/ntlmclient.h
+++ b/include/ntlmclient.h
@@ -22,6 +22,19 @@ extern "C" {
 
 typedef struct ntlm_client ntlm_client;
 
+typedef enum {
+	/**
+	 * An error occurred; more details are available by querying
+	 * `ntlm_client_errmsg`.
+	 */
+	NTLM_CLIENT_ERROR = -1,
+
+	/**
+	 * The input provided to the function is missing or invalid.
+	 */
+	NTLM_CLIENT_ERROR_INVALID_INPUT = -2,
+} ntlm_error_code;
+
 /*
  * Flags for initializing the `ntlm_client` context.  A combination of
  * these flags can be provided to `ntlm_client_init`.

--- a/tests/inputs.c
+++ b/tests/inputs.c
@@ -1,5 +1,6 @@
 #include "clar.h"
 #include "ntlm.h"
+#include "ntlm_tests.h"
 
 static ntlm_client *ntlm;
 
@@ -11,6 +12,31 @@ void test_inputs__initialize(void)
 void test_inputs__cleanup(void)
 {
 	ntlm_client_free(ntlm);
+}
+
+void test_inputs__null(void)
+{
+	const unsigned char *msg;
+	size_t msg_len;
+
+	cl_assert(ntlm_client_errmsg(NULL) != NULL);
+
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_set_hostname(NULL, "hostname", "HOSTDOMAIN"));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_set_credentials(NULL, "user", "DOMAIN", "pass!"));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_set_target(NULL, "target"));
+
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_negotiate(NULL, &msg_len, ntlm));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_negotiate(&msg, NULL, ntlm));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_negotiate(&msg, &msg_len, NULL));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_negotiate(NULL, NULL, NULL));
+
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_set_challenge(NULL, (const unsigned char *)"foo", 3));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_set_challenge(ntlm, NULL, 3));
+
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_response(NULL, &msg_len, ntlm));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_response(&msg, NULL, ntlm));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_response(&msg, &msg_len, NULL));
+	cl_must_fail_with(NTLM_CLIENT_ERROR_INVALID_INPUT, ntlm_client_response(NULL, NULL, NULL));
 }
 
 void test_inputs__set_hostname(void)

--- a/tests/ntlm_tests.h
+++ b/tests/ntlm_tests.h
@@ -5,6 +5,10 @@
 #include "ntlm.h"
 #include "util.h"
 
+#define cl_must_fail_with_(val, expr, desc) clar__assert((expr) == (val), __FILE__, __LINE__, "Expected function call to fail with " #val ": " #expr, desc, 0)
+
+#define cl_must_fail_with(val, expr) cl_must_fail_with_(val, expr, NULL)
+
 #define cl_ntlm_pass(ntlm, expr) cl_ntlm_expect((ntlm), (expr), 0, __FILE__, __LINE__)
 
 #define cl_ntlm_expect(ntlm, expr, expected, file, line) do { \


### PR DESCRIPTION
Instead of asserting, provide a unique error code (-2) when user input
is invalid/missing.